### PR TITLE
🔥 Remove `pytest.ini` in honor of `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,8 @@ classifiers = [
     'Programming Language :: Python :: Implementation :: PyPy',
     'Topic :: Software Development',
 ]
+
+[tool.pytest.ini_options]
+testpaths = [
+    "tests",
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-testpaths = tests/


### PR DESCRIPTION
Closes #21 